### PR TITLE
Override or add configuration options in values input

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,7 +7,7 @@ on:
     branches: [ master, main ]
 
 env:
-  TERRAFORM_DOCS_VERSION: "v0.11.2"
+  TERRAFORM_DOCS_VERSION: "v0.15.0"
   TFLINT_VERSION: "v0.25.0"
   TFSEC_VERSION: "v0.39.6"
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,7 +23,7 @@ repos:
 #    - id: terraform_tfsec
     - id: terraform_docs
       args:
-        - '--args=--hide providers --sort-by-required'
+        - '--args=--hide providers --sort-by required'
 
   - repo: git://github.com/pecigonzalo/pre-commit-terraform-vars
     rev: v1.0.0

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ No modules.
 | <a name="input_helm_create_namespace"></a> [helm\_create\_namespace](#input\_helm\_create\_namespace) | Whether to create k8s namespace with name defined by `k8s_namespace` | `bool` | `true` | no |
 | <a name="input_helm_release_name"></a> [helm\_release\_name](#input\_helm\_release\_name) | Helm release name | `string` | `"vector-agent"` | no |
 | <a name="input_helm_repo_url"></a> [helm\_repo\_url](#input\_helm\_repo\_url) | Helm repository | `string` | `"https://packages.timber.io/helm/latest"` | no |
-| <a name="input_k8s_namespace"></a> [k8s\_namespace](#input\_k8s\_namespace) | The K8s namespace in which the external-dns will be installed | `string` | `"kube-system"` | no |
+| <a name="input_k8s_namespace"></a> [k8s\_namespace](#input\_k8s\_namespace) | The K8s namespace in which the vector agent will be installed | `string` | `"kube-system"` | no |
 | <a name="input_settings"></a> [settings](#input\_settings) | Additional settings which will be passed to the Helm chart values to be merged with the values yaml, see https://artifacthub.io/packages/helm/vector/vector-agent | `map(any)` | `{}` | no |
 | <a name="input_values"></a> [values](#input\_values) | Additional values. Values will be merged, in order, as Helm does with multiple -f options | `string` | `""` | no |
 

--- a/README.md
+++ b/README.md
@@ -64,6 +64,9 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| <a name="input_cluster_identity_oidc_issuer"></a> [cluster\_identity\_oidc\_issuer](#input\_cluster\_identity\_oidc\_issuer) | The OIDC Identity issuer for the cluster | `string` | n/a | yes |
+| <a name="input_cluster_identity_oidc_issuer_arn"></a> [cluster\_identity\_oidc\_issuer\_arn](#input\_cluster\_identity\_oidc\_issuer\_arn) | The OIDC Identity issuer ARN for the cluster that can be used to associate IAM roles with a service account | `string` | n/a | yes |
+| <a name="input_cluster_name"></a> [cluster\_name](#input\_cluster\_name) | The name of the cluster | `string` | n/a | yes |
 | <a name="input_cloudwatch_containers_tags"></a> [cloudwatch\_containers\_tags](#input\_cloudwatch\_containers\_tags) | A map of tags to assign to the resource. | `map(any)` | `{}` | no |
 | <a name="input_cloudwatch_enabled"></a> [cloudwatch\_enabled](#input\_cloudwatch\_enabled) | Variable indicating whether default cloudwatch group with iam role is created and configured as vector sink | `bool` | `false` | no |
 | <a name="input_cloudwatch_group_containers_kms_key_id"></a> [cloudwatch\_group\_containers\_kms\_key\_id](#input\_cloudwatch\_group\_containers\_kms\_key\_id) | The ARN of the KMS Key to use when encrypting log data. Please note, after the AWS KMS CMK is disassociated from the log group, AWS CloudWatch Logs stops encrypting newly ingested data for the log group. All previously ingested data remains encrypted, and AWS CloudWatch Logs requires permissions for the CMK whenever the encrypted data is requested. | `string` | `""` | no |
@@ -73,16 +76,13 @@ No modules.
 | <a name="input_cloudwatch_group_nodes_retention"></a> [cloudwatch\_group\_nodes\_retention](#input\_cloudwatch\_group\_nodes\_retention) | Specifies the number of days you want to retain log events in the specified log group. Possible values are: 1, 3, 5, 7, 14, 30, 60, 90, 120, 150, 180, 365, 400, 545, 731, 1827, 3653, and 0. If you select 0, the events in the log group are always retained and never expire. | `number` | `14` | no |
 | <a name="input_cloudwatch_nodes_tags"></a> [cloudwatch\_nodes\_tags](#input\_cloudwatch\_nodes\_tags) | A map of tags to assign to the resource. | `map(any)` | `{}` | no |
 | <a name="input_cloudwatch_role_name_prefix"></a> [cloudwatch\_role\_name\_prefix](#input\_cloudwatch\_role\_name\_prefix) | The role name prefix for vector cloudwatch ingest | `string` | `"eks-irsa"` | no |
-| <a name="input_cluster_identity_oidc_issuer"></a> [cluster\_identity\_oidc\_issuer](#input\_cluster\_identity\_oidc\_issuer) | The OIDC Identity issuer for the cluster | `string` | `""` | no |
-| <a name="input_cluster_identity_oidc_issuer_arn"></a> [cluster\_identity\_oidc\_issuer\_arn](#input\_cluster\_identity\_oidc\_issuer\_arn) | The OIDC Identity issuer ARN for the cluster that can be used to associate IAM roles with a service account | `string` | `""` | no |
-| <a name="input_cluster_name"></a> [cluster\_name](#input\_cluster\_name) | The name of the cluster | `string` | `""` | no |
 | <a name="input_enabled"></a> [enabled](#input\_enabled) | Variable indicating whether deployment is enabled | `bool` | `true` | no |
 | <a name="input_helm_chart_name"></a> [helm\_chart\_name](#input\_helm\_chart\_name) | Helm chart name to be installed | `string` | `"vector-agent"` | no |
 | <a name="input_helm_chart_version"></a> [helm\_chart\_version](#input\_helm\_chart\_version) | Version of the Helm chart | `string` | `"0.15.1"` | no |
+| <a name="input_helm_create_namespace"></a> [helm\_create\_namespace](#input\_helm\_create\_namespace) | Whether to create k8s namespace with name defined by `k8s_namespace` | `bool` | `true` | no |
 | <a name="input_helm_release_name"></a> [helm\_release\_name](#input\_helm\_release\_name) | Helm release name | `string` | `"vector-agent"` | no |
 | <a name="input_helm_repo_url"></a> [helm\_repo\_url](#input\_helm\_repo\_url) | Helm repository | `string` | `"https://packages.timber.io/helm/latest"` | no |
-| <a name="input_k8s_create_namespace"></a> [k8s\_create\_namespace](#input\_k8s\_create\_namespace) | Whether to create k8s namespace with name defined by `k8s_namespace` | `bool` | `true` | no |
-| <a name="input_k8s_namespace"></a> [k8s\_namespace](#input\_k8s\_namespace) | The K8s namespace in which the ingress-nginx has been created | `string` | `"logging"` | no |
+| <a name="input_k8s_namespace"></a> [k8s\_namespace](#input\_k8s\_namespace) | The K8s namespace in which the external-dns will be installed | `string` | `"kube-system"` | no |
 | <a name="input_settings"></a> [settings](#input\_settings) | Additional settings which will be passed to the Helm chart values to be merged with the values yaml, see https://artifacthub.io/packages/helm/vector/vector-agent | `map(any)` | `{}` | no |
 | <a name="input_values"></a> [values](#input\_values) | Additional values. Values will be merged, in order, as Helm does with multiple -f options | `string` | `""` | no |
 

--- a/README.md
+++ b/README.md
@@ -36,58 +36,61 @@ See [Basic example](examples/basic/README.md) for further information.
 
 | Name | Version |
 |------|---------|
-| terraform | >= 0.13 |
-| aws | >= 2.0 |
-| helm | >= 1.0 |
-| kubernetes | >= 1.10 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 2.0 |
+| <a name="requirement_helm"></a> [helm](#requirement\_helm) | >= 1.0 |
+| <a name="requirement_utils"></a> [utils](#requirement\_utils) | >= 0.12.0 |
 
 ## Modules
 
-No Modules.
+No modules.
 
 ## Resources
 
-| Name |
-|------|
-| [aws_cloudwatch_log_group](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_group) |
-| [aws_iam_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) |
-| [aws_iam_policy_document](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) |
-| [aws_iam_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) |
-| [aws_iam_role_policy_attachment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) |
-| [aws_region](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) |
-| [helm_release](https://registry.terraform.io/providers/hashicorp/helm/latest/docs/resources/release) |
+| Name | Type |
+|------|------|
+| [aws_cloudwatch_log_group.cloudwatch_containers](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_group) | resource |
+| [aws_cloudwatch_log_group.cloudwatch_nodes](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_group) | resource |
+| [aws_iam_policy.cloudwatch](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
+| [aws_iam_role.cloudwatch](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
+| [aws_iam_role_policy_attachment.cloudwatch](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
+| [helm_release.self](https://registry.terraform.io/providers/hashicorp/helm/latest/docs/resources/release) | resource |
+| [aws_iam_policy_document.cloudwatch](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.vector_irsa_assume](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) | data source |
+| [utils_deep_merge_yaml.values](https://registry.terraform.io/providers/cloudposse/utils/latest/docs/data-sources/deep_merge_yaml) | data source |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| cloudwatch\_containers\_tags | A map of tags to assign to the resource. | `map(any)` | `{}` | no |
-| cloudwatch\_enabled | Variable indicating whether default cloudwatch group with iam role is created and configured as vector sink | `bool` | `false` | no |
-| cloudwatch\_group\_containers\_kms\_key\_id | The ARN of the KMS Key to use when encrypting log data. Please note, after the AWS KMS CMK is disassociated from the log group, AWS CloudWatch Logs stops encrypting newly ingested data for the log group. All previously ingested data remains encrypted, and AWS CloudWatch Logs requires permissions for the CMK whenever the encrypted data is requested. | `string` | `""` | no |
-| cloudwatch\_group\_containers\_retention | Specifies the number of days you want to retain log events in the specified log group. Possible values are: 1, 3, 5, 7, 14, 30, 60, 90, 120, 150, 180, 365, 400, 545, 731, 1827, 3653, and 0. If you select 0, the events in the log group are always retained and never expire. | `number` | `14` | no |
-| cloudwatch\_group\_name\_prefix | The name of the log group | `string` | `"/aws/eks"` | no |
-| cloudwatch\_group\_nodes\_kms\_key\_id | The ARN of the KMS Key to use when encrypting log data. Please note, after the AWS KMS CMK is disassociated from the log group, AWS CloudWatch Logs stops encrypting newly ingested data for the log group. All previously ingested data remains encrypted, and AWS CloudWatch Logs requires permissions for the CMK whenever the encrypted data is requested. | `string` | `""` | no |
-| cloudwatch\_group\_nodes\_retention | Specifies the number of days you want to retain log events in the specified log group. Possible values are: 1, 3, 5, 7, 14, 30, 60, 90, 120, 150, 180, 365, 400, 545, 731, 1827, 3653, and 0. If you select 0, the events in the log group are always retained and never expire. | `number` | `14` | no |
-| cloudwatch\_nodes\_tags | A map of tags to assign to the resource. | `map(any)` | `{}` | no |
-| cloudwatch\_role\_name\_prefix | The role name prefix for vector cloudwatch ingest | `string` | `"eks-irsa"` | no |
-| cluster\_identity\_oidc\_issuer | The OIDC Identity issuer for the cluster | `string` | `""` | no |
-| cluster\_identity\_oidc\_issuer\_arn | The OIDC Identity issuer ARN for the cluster that can be used to associate IAM roles with a service account | `string` | `""` | no |
-| cluster\_name | The name of the cluster | `string` | `""` | no |
-| enabled | Variable indicating whether deployment is enabled | `bool` | `true` | no |
-| helm\_chart\_name | Helm chart name to be installed | `string` | `"vector-agent"` | no |
-| helm\_chart\_version | Version of the Helm chart | `string` | `"0.12.2"` | no |
-| helm\_release\_name | Helm release name | `string` | `"vector-agent"` | no |
-| helm\_repo\_url | Helm repository | `string` | `"https://packages.timber.io/helm/latest"` | no |
-| k8s\_create\_namespace | Whether to create k8s namespace with name defined by `k8s_namespace` | `bool` | `true` | no |
-| k8s\_namespace | The K8s namespace in which the ingress-nginx has been created | `string` | `"logging"` | no |
-| settings | Additional settings which will be passed to the Helm chart values to be merged with the values yaml, see https://artifacthub.io/packages/helm/vector/vector-agent | `map(any)` | `{}` | no |
-| values | Additional list of values in raw yaml to pass to helm. Values will be merged, in order, as Helm does with multiple -f options | `list(string)` | <pre>[<br>  ""<br>]</pre> | no |
+| <a name="input_cloudwatch_containers_tags"></a> [cloudwatch\_containers\_tags](#input\_cloudwatch\_containers\_tags) | A map of tags to assign to the resource. | `map(any)` | `{}` | no |
+| <a name="input_cloudwatch_enabled"></a> [cloudwatch\_enabled](#input\_cloudwatch\_enabled) | Variable indicating whether default cloudwatch group with iam role is created and configured as vector sink | `bool` | `false` | no |
+| <a name="input_cloudwatch_group_containers_kms_key_id"></a> [cloudwatch\_group\_containers\_kms\_key\_id](#input\_cloudwatch\_group\_containers\_kms\_key\_id) | The ARN of the KMS Key to use when encrypting log data. Please note, after the AWS KMS CMK is disassociated from the log group, AWS CloudWatch Logs stops encrypting newly ingested data for the log group. All previously ingested data remains encrypted, and AWS CloudWatch Logs requires permissions for the CMK whenever the encrypted data is requested. | `string` | `""` | no |
+| <a name="input_cloudwatch_group_containers_retention"></a> [cloudwatch\_group\_containers\_retention](#input\_cloudwatch\_group\_containers\_retention) | Specifies the number of days you want to retain log events in the specified log group. Possible values are: 1, 3, 5, 7, 14, 30, 60, 90, 120, 150, 180, 365, 400, 545, 731, 1827, 3653, and 0. If you select 0, the events in the log group are always retained and never expire. | `number` | `14` | no |
+| <a name="input_cloudwatch_group_name_prefix"></a> [cloudwatch\_group\_name\_prefix](#input\_cloudwatch\_group\_name\_prefix) | The name of the log group | `string` | `"/aws/eks"` | no |
+| <a name="input_cloudwatch_group_nodes_kms_key_id"></a> [cloudwatch\_group\_nodes\_kms\_key\_id](#input\_cloudwatch\_group\_nodes\_kms\_key\_id) | The ARN of the KMS Key to use when encrypting log data. Please note, after the AWS KMS CMK is disassociated from the log group, AWS CloudWatch Logs stops encrypting newly ingested data for the log group. All previously ingested data remains encrypted, and AWS CloudWatch Logs requires permissions for the CMK whenever the encrypted data is requested. | `string` | `""` | no |
+| <a name="input_cloudwatch_group_nodes_retention"></a> [cloudwatch\_group\_nodes\_retention](#input\_cloudwatch\_group\_nodes\_retention) | Specifies the number of days you want to retain log events in the specified log group. Possible values are: 1, 3, 5, 7, 14, 30, 60, 90, 120, 150, 180, 365, 400, 545, 731, 1827, 3653, and 0. If you select 0, the events in the log group are always retained and never expire. | `number` | `14` | no |
+| <a name="input_cloudwatch_nodes_tags"></a> [cloudwatch\_nodes\_tags](#input\_cloudwatch\_nodes\_tags) | A map of tags to assign to the resource. | `map(any)` | `{}` | no |
+| <a name="input_cloudwatch_role_name_prefix"></a> [cloudwatch\_role\_name\_prefix](#input\_cloudwatch\_role\_name\_prefix) | The role name prefix for vector cloudwatch ingest | `string` | `"eks-irsa"` | no |
+| <a name="input_cluster_identity_oidc_issuer"></a> [cluster\_identity\_oidc\_issuer](#input\_cluster\_identity\_oidc\_issuer) | The OIDC Identity issuer for the cluster | `string` | `""` | no |
+| <a name="input_cluster_identity_oidc_issuer_arn"></a> [cluster\_identity\_oidc\_issuer\_arn](#input\_cluster\_identity\_oidc\_issuer\_arn) | The OIDC Identity issuer ARN for the cluster that can be used to associate IAM roles with a service account | `string` | `""` | no |
+| <a name="input_cluster_name"></a> [cluster\_name](#input\_cluster\_name) | The name of the cluster | `string` | `""` | no |
+| <a name="input_enabled"></a> [enabled](#input\_enabled) | Variable indicating whether deployment is enabled | `bool` | `true` | no |
+| <a name="input_helm_chart_name"></a> [helm\_chart\_name](#input\_helm\_chart\_name) | Helm chart name to be installed | `string` | `"vector-agent"` | no |
+| <a name="input_helm_chart_version"></a> [helm\_chart\_version](#input\_helm\_chart\_version) | Version of the Helm chart | `string` | `"0.15.1"` | no |
+| <a name="input_helm_release_name"></a> [helm\_release\_name](#input\_helm\_release\_name) | Helm release name | `string` | `"vector-agent"` | no |
+| <a name="input_helm_repo_url"></a> [helm\_repo\_url](#input\_helm\_repo\_url) | Helm repository | `string` | `"https://packages.timber.io/helm/latest"` | no |
+| <a name="input_k8s_create_namespace"></a> [k8s\_create\_namespace](#input\_k8s\_create\_namespace) | Whether to create k8s namespace with name defined by `k8s_namespace` | `bool` | `true` | no |
+| <a name="input_k8s_namespace"></a> [k8s\_namespace](#input\_k8s\_namespace) | The K8s namespace in which the ingress-nginx has been created | `string` | `"logging"` | no |
+| <a name="input_settings"></a> [settings](#input\_settings) | Additional settings which will be passed to the Helm chart values to be merged with the values yaml, see https://artifacthub.io/packages/helm/vector/vector-agent | `map(any)` | `{}` | no |
+| <a name="input_values"></a> [values](#input\_values) | Additional values. Values will be merged, in order, as Helm does with multiple -f options | `string` | `""` | no |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| helm\_release\_attributes | Helm release attributes |
+| <a name="output_helm_release_attributes"></a> [helm\_release\_attributes](#output\_helm\_release\_attributes) | Helm release attributes |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 
 ## Contributing and reporting issues

--- a/examples/basic/README.md
+++ b/examples/basic/README.md
@@ -11,24 +11,24 @@ No requirements.
 
 | Name | Source | Version |
 |------|--------|---------|
-| eks_cluster | cloudposse/eks-cluster/aws |  |
-| eks_workers | cloudposse/eks-workers/aws |  |
-| vector_log_cloudwatch | ../../ |  |
-| vector_log_default | ../../ |  |
-| vpc | terraform-aws-modules/vpc/aws |  |
+| <a name="module_eks_cluster"></a> [eks\_cluster](#module\_eks\_cluster) | cloudposse/eks-cluster/aws | n/a |
+| <a name="module_eks_workers"></a> [eks\_workers](#module\_eks\_workers) | cloudposse/eks-workers/aws | n/a |
+| <a name="module_vector_log_cloudwatch"></a> [vector\_log\_cloudwatch](#module\_vector\_log\_cloudwatch) | ../../ | n/a |
+| <a name="module_vector_log_default"></a> [vector\_log\_default](#module\_vector\_log\_default) | ../../ | n/a |
+| <a name="module_vpc"></a> [vpc](#module\_vpc) | terraform-aws-modules/vpc/aws | n/a |
 
 ## Resources
 
-| Name |
-|------|
-| [aws_eks_cluster](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/eks_cluster) |
-| [aws_eks_cluster_auth](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/eks_cluster_auth) |
+| Name | Type |
+|------|------|
+| [aws_eks_cluster.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/eks_cluster) | data source |
+| [aws_eks_cluster_auth.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/eks_cluster_auth) | data source |
 
 ## Inputs
 
-No input.
+No inputs.
 
 ## Outputs
 
-No output.
+No outputs.
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/basic/README.md
+++ b/examples/basic/README.md
@@ -11,11 +11,11 @@ No requirements.
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_eks_cluster"></a> [eks\_cluster](#module\_eks\_cluster) | cloudposse/eks-cluster/aws | n/a |
-| <a name="module_eks_workers"></a> [eks\_workers](#module\_eks\_workers) | cloudposse/eks-workers/aws | n/a |
+| <a name="module_eks_cluster"></a> [eks\_cluster](#module\_eks\_cluster) | cloudposse/eks-cluster/aws | 0.43.2 |
+| <a name="module_eks_node_group"></a> [eks\_node\_group](#module\_eks\_node\_group) | cloudposse/eks-node-group/aws | 0.25.0 |
 | <a name="module_vector_log_cloudwatch"></a> [vector\_log\_cloudwatch](#module\_vector\_log\_cloudwatch) | ../../ | n/a |
 | <a name="module_vector_log_default"></a> [vector\_log\_default](#module\_vector\_log\_default) | ../../ | n/a |
-| <a name="module_vpc"></a> [vpc](#module\_vpc) | terraform-aws-modules/vpc/aws | n/a |
+| <a name="module_vpc"></a> [vpc](#module\_vpc) | terraform-aws-modules/vpc/aws | 3.6.0 |
 
 ## Resources
 

--- a/examples/basic/main.tf
+++ b/examples/basic/main.tf
@@ -14,7 +14,7 @@ module "eks_cluster" {
   region     = "eu-central-1"
   subnet_ids = module.vpc.public_subnets
   vpc_id     = module.vpc.vpc_id
-  name       = "cluster-autoscaler"
+  name       = "vector-agent-log"
 
   workers_security_group_ids = [module.eks_workers.security_group_id]
   workers_role_arns          = [module.eks_workers.workers_role_arn]
@@ -25,8 +25,7 @@ module "eks_workers" {
 
   cluster_certificate_authority_data = module.eks_cluster.eks_cluster_certificate_authority_data
   cluster_endpoint                   = module.eks_cluster.eks_cluster_endpoint
-  cluster_name                       = module.eks_cluster.eks_cluster_id
-  cluster_security_group_id          = module.eks_cluster.security_group_id
+  cluster_name                       = "vector-agent-log"
   instance_type                      = "t3.medium"
   max_size                           = 1
   min_size                           = 1

--- a/examples/basic/main.tf
+++ b/examples/basic/main.tf
@@ -1,7 +1,8 @@
 module "vpc" {
-  source = "terraform-aws-modules/vpc/aws"
+  source  = "terraform-aws-modules/vpc/aws"
+  version = "3.6.0"
 
-  name               = "cluster-autoscaler-vpc"
+  name               = "vector-agent-log-vpc"
   cidr               = "10.0.0.0/16"
   azs                = ["eu-central-1a", "eu-central-1b"]
   public_subnets     = ["10.0.101.0/24", "10.0.102.0/24"]
@@ -9,33 +10,27 @@ module "vpc" {
 }
 
 module "eks_cluster" {
-  source = "cloudposse/eks-cluster/aws"
+  source  = "cloudposse/eks-cluster/aws"
+  version = "0.43.2"
 
   region     = "eu-central-1"
   subnet_ids = module.vpc.public_subnets
   vpc_id     = module.vpc.vpc_id
   name       = "vector-agent-log"
-
-  workers_security_group_ids = [module.eks_workers.security_group_id]
-  workers_role_arns          = [module.eks_workers.workers_role_arn]
 }
 
-module "eks_workers" {
-  source = "cloudposse/eks-workers/aws"
+module "eks_node_group" {
+  source  = "cloudposse/eks-node-group/aws"
+  version = "0.25.0"
 
-  cluster_certificate_authority_data = module.eks_cluster.eks_cluster_certificate_authority_data
-  cluster_endpoint                   = module.eks_cluster.eks_cluster_endpoint
-  cluster_name                       = "vector-agent-log"
-  instance_type                      = "t3.medium"
-  max_size                           = 1
-  min_size                           = 1
-  subnet_ids                         = module.vpc.public_subnets
-  vpc_id                             = module.vpc.vpc_id
-
-  associate_public_ip_address = true
+  cluster_name   = "vector-agent-log"
+  instance_types = ["t3.medium"]
+  subnet_ids     = module.vpc.public_subnets
+  min_size       = 1
+  desired_size   = 1
+  max_size       = 2
+  depends_on     = [module.eks_cluster.kubernetes_config_map_id]
 }
-
-# Use the module:
 
 module "vector_log_cloudwatch" {
   source = "../../"
@@ -78,13 +73,12 @@ module "vector_log_cloudwatch" {
     # "extraEnv[2].valueFrom.secretKeyRef.key" = "varname3-key"
   }
 
-  values = [<<-EOF
+  values = <<-EOF
     sources:
       foo:
         type = "journald"
         include_units = ["foo.service"]
   EOF
-  ]
 }
 
 module "vector_log_default" {

--- a/examples/basic/main.tf
+++ b/examples/basic/main.tf
@@ -83,4 +83,8 @@ module "vector_log_cloudwatch" {
 
 module "vector_log_default" {
   source = "../../"
+
+  cluster_name                     = module.eks_cluster.eks_cluster_id
+  cluster_identity_oidc_issuer     = module.eks_cluster.eks_cluster_identity_oidc_issuer
+  cluster_identity_oidc_issuer_arn = module.eks_cluster.eks_cluster_identity_oidc_issuer_arn
 }

--- a/examples/basic/providers.tf
+++ b/examples/basic/providers.tf
@@ -10,12 +10,6 @@ data "aws_eks_cluster_auth" "this" {
   name = module.eks_cluster.eks_cluster_id
 }
 
-provider "kubernetes" {
-  host                   = data.aws_eks_cluster.this.endpoint
-  cluster_ca_certificate = base64decode(data.aws_eks_cluster.this.certificate_authority.0.data)
-  token                  = data.aws_eks_cluster_auth.this.token
-}
-
 provider "helm" {
   kubernetes {
     host                   = data.aws_eks_cluster.this.endpoint

--- a/iam.tf
+++ b/iam.tf
@@ -28,9 +28,7 @@ data "aws_iam_policy_document" "cloudwatch" {
   statement {
     sid = "AllowDescribeCloudWatchLogsForVector"
 
-    actions = [
-      "logs:DescribeLogGroups",
-    ]
+    actions   = ["logs:DescribeLogGroups"]
     resources = ["*"]
   }
 

--- a/iam.tf
+++ b/iam.tf
@@ -47,7 +47,6 @@ data "aws_iam_policy_document" "cloudwatch" {
   }
 }
 
-
 resource "aws_iam_policy" "cloudwatch" {
   count = var.enabled && var.cloudwatch_enabled ? 1 : 0
 

--- a/main.tf
+++ b/main.tf
@@ -96,7 +96,7 @@ resource "helm_release" "self" {
   repository       = var.helm_repo_url
   chart            = var.helm_chart_name
   version          = var.helm_chart_version
-  create_namespace = var.k8s_create_namespace
+  create_namespace = var.helm_create_namespace
   namespace        = var.k8s_namespace
   name             = var.helm_release_name
 

--- a/main.tf
+++ b/main.tf
@@ -5,95 +5,104 @@ locals {
   cloudwatch_group_name_containers = try(aws_cloudwatch_log_group.cloudwatch_containers[0].name, "")
   cloudwatch_group_name_nodes      = try(aws_cloudwatch_log_group.cloudwatch_nodes[0].name, "")
 
-  values_default = <<-EOF
-    podValuesChecksumAnnotation: true
+  values_default = yamlencode({
+    "podValuesChecksumAnnotation" : "true",
+    "tolerations" : [{
+      "operator" : "Exists",
+      "effect" : "NoSchedule"
+    }],
+    "serviceAccount" : {
+      "name" : local.k8s_service_account_name,
+      "annotations" : {
+        "eks.amazonaws.com/role-arn" : local.k8s_service_account_role
+      }
+    },
+    "extraVolumes" : [{
+      "name" : "etc",
+      "hostPath" : {
+        "path" : "/etc"
+      }
+    }],
+    "extraVolumeMounts" : [{
+      "name" : "etc",
+      "mountPath" : "/etc/machine-id",
+      "subPath" : "machine-id",
+      "readOnly" : true
+    }],
+    "customConfig" : {
+      "sources" : {
+        "kubelet" : {
+          "type" : "journald",
+          "include_units" : ["kubelet"]
+        },
+        "containerd" : {
+          "type" : "journald",
+          "include_units" : ["containerd"]
+        },
+        "docker" : {
+          "type" : "journald",
+          "include_units" : ["docker"]
+        },
+        "kubernetes_logs" : {
+          "type" : "kubernetes_logs"
+        }
+      }
+    }
+  })
 
-    tolerations:
-      - operator: Exists
-        effect: NoSchedule
+  values_sink_cloudwatch = yamlencode({
+    "customConfig" : {
+      "sinks" : {
+        "cloudwatch_containers" : {
+          "type" : "aws_cloudwatch_logs",
+          "inputs" : ["kubernetes_logs"],
+          "region" : data.aws_region.current.name,
+          "group_name" : local.cloudwatch_group_name_containers,
+          "stream_name" : "{{`{{ kubernetes.pod_namespace }}-{{ kubernetes.pod_name }}-{{ kubernetes.container_name }}`}}",
+          "create_missing_group" : false,
+          "encoding" : {
+            "codec" : "json"
+          }
+        },
+        "cloudwatch_journal" : {
+          "type" : "aws_cloudwatch_logs",
+          "inputs" : ["kubelet", "containerd", "docker"],
+          "region" : data.aws_region.current.name,
+          "group_name" : local.cloudwatch_group_name_nodes,
+          "stream_name" : "{{`{{ host }}-{{ _SYSTEMD_UNIT }}`}}",
+          "create_missing_group" : false,
+          "encoding" : {
+            "codec" : "json"
+          }
+        }
+      }
+    }
+  })
+}
 
-    serviceAccount:
-      name: "${local.k8s_service_account_name}"
-      annotations:
-        eks.amazonaws.com/role-arn: ${local.k8s_service_account_role}
-
-    # https://github.com/timberio/vector/issues/5225
-    extraVolumes:
-      - name: etc
-        hostPath:
-          path: /etc
-
-    # https://github.com/timberio/vector/issues/5225
-    extraVolumeMounts:
-      - name: etc
-        mountPath: /etc/machine-id
-        subPath: machine-id
-        readOnly: true
-
-    sources:
-      kubelet:
-        type: "journald"
-        include_units: ["kubelet"]
-      containerd:
-        type: "journald"
-        include_units: ["containerd"]
-      docker:
-        type: "journald"
-        include_units: ["docker"]
-  EOF
-
-  values_service_account_cloudwatch = <<-EOF
-    serviceAccount:
-      name: "${local.k8s_service_account_name}"
-      annotations:
-        eks.amazonaws.com/role-arn: ${local.k8s_service_account_role}
-  EOF
-
-  values_sink_cloudwatch = <<-EOF
-    sinks:
-      cloudwatch_containers:
-        rawConfig: |
-          type = "aws_cloudwatch_logs"
-          inputs = ["kubernetes_logs"]
-          region = "${data.aws_region.current.name}"
-          group_name = "${local.cloudwatch_group_name_containers}"
-          stream_name = "{{ kubernetes.pod_namespace }}-{{ kubernetes.pod_name }}-{{ kubernetes.container_name }}"
-          create_missing_group = false
-          encoding.codec = "json"
-      cloudwatch_journal:
-        rawConfig: |
-          type = "aws_cloudwatch_logs"
-          inputs = ["kubelet", "containerd", "docker"]
-          region = "${data.aws_region.current.name}"
-          group_name = "${local.cloudwatch_group_name_nodes}"
-          stream_name = "{{ host }}-{{ _SYSTEMD_UNIT }}"
-          create_missing_group = false
-          encoding.codec = "json"
-  EOF
-
-  values = [
+data "utils_deep_merge_yaml" "values" {
+  count = var.enabled ? 1 : 0
+  input = compact([
     local.values_default,
     var.cloudwatch_enabled ? local.values_sink_cloudwatch : "",
-  ]
+    var.values
+  ])
 }
 
 data "aws_region" "current" {}
 
 resource "helm_release" "self" {
-  count = var.enabled ? 1 : 0
-
-  repository = var.helm_repo_url
-  chart      = var.helm_chart_name
-  version    = var.helm_chart_version
-
+  count            = var.enabled ? 1 : 0
+  repository       = var.helm_repo_url
+  chart            = var.helm_chart_name
+  version          = var.helm_chart_version
   create_namespace = var.k8s_create_namespace
   namespace        = var.k8s_namespace
   name             = var.helm_release_name
 
-  values = concat(
-    local.values,
-    var.values
-  )
+  values = [
+    data.utils_deep_merge_yaml.values[0].output
+  ]
 
   dynamic "set" {
     for_each = var.settings

--- a/variables.tf
+++ b/variables.tf
@@ -52,7 +52,7 @@ variable "helm_create_namespace" {
 variable "k8s_namespace" {
   type        = string
   default     = "kube-system"
-  description = "The K8s namespace in which the external-dns will be installed"
+  description = "The K8s namespace in which the vector agent will be installed"
 }
 
 variable "settings" {

--- a/variables.tf
+++ b/variables.tf
@@ -1,11 +1,24 @@
-# vector-agent
 variable "enabled" {
   type        = bool
   default     = true
   description = "Variable indicating whether deployment is enabled"
 }
 
-# Helm
+variable "cluster_name" {
+  type        = string
+  description = "The name of the cluster"
+}
+
+variable "cluster_identity_oidc_issuer" {
+  type        = string
+  description = "The OIDC Identity issuer for the cluster"
+}
+
+variable "cluster_identity_oidc_issuer_arn" {
+  type        = string
+  description = "The OIDC Identity issuer ARN for the cluster that can be used to associate IAM roles with a service account"
+}
+
 variable "helm_chart_name" {
   type        = string
   default     = "vector-agent"
@@ -30,8 +43,7 @@ variable "helm_repo_url" {
   description = "Helm repository"
 }
 
-# K8s
-variable "k8s_create_namespace" {
+variable "helm_create_namespace" {
   type        = bool
   default     = true
   description = "Whether to create k8s namespace with name defined by `k8s_namespace`"
@@ -39,8 +51,8 @@ variable "k8s_create_namespace" {
 
 variable "k8s_namespace" {
   type        = string
-  default     = "logging"
-  description = "The K8s namespace in which the ingress-nginx has been created"
+  default     = "kube-system"
+  description = "The K8s namespace in which the external-dns will be installed"
 }
 
 variable "settings" {
@@ -108,23 +120,4 @@ variable "cloudwatch_role_name_prefix" {
   type        = string
   default     = "eks-irsa"
   description = "The role name prefix for vector cloudwatch ingest"
-}
-
-# IAM service account roles (IRSA)
-variable "cluster_name" {
-  type        = string
-  default     = ""
-  description = "The name of the cluster"
-}
-
-variable "cluster_identity_oidc_issuer" {
-  type        = string
-  default     = ""
-  description = "The OIDC Identity issuer for the cluster"
-}
-
-variable "cluster_identity_oidc_issuer_arn" {
-  type        = string
-  default     = ""
-  description = "The OIDC Identity issuer ARN for the cluster that can be used to associate IAM roles with a service account"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -14,7 +14,7 @@ variable "helm_chart_name" {
 
 variable "helm_chart_version" {
   type        = string
-  default     = "0.12.2"
+  default     = "0.15.1"
   description = "Version of the Helm chart"
 }
 
@@ -50,9 +50,9 @@ variable "settings" {
 }
 
 variable "values" {
-  type        = list(string)
-  default     = [""]
-  description = "Additional list of values in raw yaml to pass to helm. Values will be merged, in order, as Helm does with multiple -f options"
+  type        = string
+  default     = ""
+  description = "Additional values. Values will be merged, in order, as Helm does with multiple -f options"
 }
 
 # Cloudwatch & Vector cloudwatch sink configuration

--- a/versions.tf
+++ b/versions.tf
@@ -10,9 +10,9 @@ terraform {
       source  = "hashicorp/helm"
       version = ">= 1.0"
     }
-    kubernetes = {
-      source  = "hashicorp/kubernetes"
-      version = ">= 1.10"
+    utils = {
+      source  = "cloudposse/utils"
+      version = ">= 0.12.0"
     }
   }
 }


### PR DESCRIPTION
Changes:
* Add ability to override or add configuration options in default values 
* Delegate Kubernetes namespace creation to helm provider from Kubernetes provider
* Remove fake dependency variable in favor of terraform built-in module dependency
* Bump default chart version to the 0.15.1

Breaking changes:
* Removes fake dependency variable `mod_dependency` in favor of terraform built-in module dependency injection
Signed-off-by: Ondřej Šmalec <ondrej.smalec@lablabs.io>