### PR TITLE
Opensearch

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,13 +59,17 @@ No modules.
 | [aws_cloudwatch_log_group.cloudwatch_containers](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_group) | resource |
 | [aws_cloudwatch_log_group.cloudwatch_nodes](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_group) | resource |
 | [aws_iam_policy.cloudwatch](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
+| [aws_iam_policy.opensearch](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_role.vector](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_role_policy_attachment.cloudwatch](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_iam_role_policy_attachment.opensearch](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [helm_release.argocd_application](https://registry.terraform.io/providers/hashicorp/helm/latest/docs/resources/release) | resource |
 | [helm_release.self](https://registry.terraform.io/providers/hashicorp/helm/latest/docs/resources/release) | resource |
 | [kubernetes_manifest.self](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/manifest) | resource |
 | [aws_iam_policy_document.cloudwatch](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.cloudwatch_assume](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.opensearch](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.opensearch_assume](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.vector_irsa](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) | data source |
 | [utils_deep_merge_yaml.argo_application_values](https://registry.terraform.io/providers/cloudposse/utils/latest/docs/data-sources/deep_merge_yaml) | data source |
@@ -106,6 +110,9 @@ No modules.
 | <a name="input_k8s_namespace"></a> [k8s\_namespace](#input\_k8s\_namespace) | The K8s namespace in which the vector agent will be installed | `string` | `"kube-system"` | no |
 | <a name="input_k8s_rbac_create"></a> [k8s\_rbac\_create](#input\_k8s\_rbac\_create) | Whether to create and use RBAC resources | `bool` | `true` | no |
 | <a name="input_k8s_service_account_create"></a> [k8s\_service\_account\_create](#input\_k8s\_service\_account\_create) | Whether to create Service Account | `bool` | `true` | no |
+| <a name="input_opensearch_domain_action"></a> [opensearch\_domain\_action](#input\_opensearch\_domain\_action) | List of actions to allow for the vector role, _e.g._ `es:ESHttpGet`, `es:ESHttpPut`, `es:ESHttpPost` | `list(string)` | <pre>[<br>  "es:ESHttpGet",<br>  "es:ESHttpPut",<br>  "es:ESHttpPost"<br>]</pre> | no |
+| <a name="input_opensearch_domain_arn"></a> [opensearch\_domain\_arn](#input\_opensearch\_domain\_arn) | List of OpenSearch arns to allow for the vector role. Default all OpenSearch domains. | `list(string)` | <pre>[<br>  "*"<br>]</pre> | no |
+| <a name="input_opensearch_enabled"></a> [opensearch\_enabled](#input\_opensearch\_enabled) | Variable indicating whether default opensearch group with iam role is created and configured as vector sink | `bool` | `false` | no |
 | <a name="input_opensearch_endpoint"></a> [opensearch\_endpoint](#input\_opensearch\_endpoint) | Domain-specific endpoint used to submit index and data upload requests | `string` | `"https://opensearch.example.com"` | no |
 | <a name="input_settings"></a> [settings](#input\_settings) | Additional settings which will be passed to the Helm chart values to be merged with the values yaml, see https://artifacthub.io/packages/helm/vector/vector-agent | `map(any)` | `{}` | no |
 | <a name="input_values"></a> [values](#input\_values) | Additional values. Values will be merged, in order, as Helm does with multiple -f options | `string` | `""` | no |
@@ -116,6 +123,7 @@ No modules.
 |------|-------------|
 | <a name="output_helm_release_application_metadata"></a> [helm\_release\_application\_metadata](#output\_helm\_release\_application\_metadata) | Argo application helm release attributes |
 | <a name="output_helm_release_metadata"></a> [helm\_release\_metadata](#output\_helm\_release\_metadata) | Helm release attributes |
+| <a name="output_iam_role_attributes"></a> [iam\_role\_attributes](#output\_iam\_role\_attributes) | Vector IAM role atributes |
 | <a name="output_kubernetes_application_attributes"></a> [kubernetes\_application\_attributes](#output\_kubernetes\_application\_attributes) | Argo kubernetes manifest attributes |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ To overcome this issue, the module deploys the ArgoCD application object using t
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 2.0 |
 | <a name="requirement_helm"></a> [helm](#requirement\_helm) | >= 1.0 |
+| <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | >= 2.6.0 |
 | <a name="requirement_utils"></a> [utils](#requirement\_utils) | >= 0.12.0 |
 
 ## Modules
@@ -58,13 +59,14 @@ No modules.
 | [aws_cloudwatch_log_group.cloudwatch_containers](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_group) | resource |
 | [aws_cloudwatch_log_group.cloudwatch_nodes](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_group) | resource |
 | [aws_iam_policy.cloudwatch](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
-| [aws_iam_role.cloudwatch](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
+| [aws_iam_role.vector](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_role_policy_attachment.cloudwatch](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [helm_release.argocd_application](https://registry.terraform.io/providers/hashicorp/helm/latest/docs/resources/release) | resource |
 | [helm_release.self](https://registry.terraform.io/providers/hashicorp/helm/latest/docs/resources/release) | resource |
 | [kubernetes_manifest.self](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/manifest) | resource |
 | [aws_iam_policy_document.cloudwatch](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
-| [aws_iam_policy_document.vector_irsa_assume](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.cloudwatch_assume](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.vector_irsa](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) | data source |
 | [utils_deep_merge_yaml.argo_application_values](https://registry.terraform.io/providers/cloudposse/utils/latest/docs/data-sources/deep_merge_yaml) | data source |
 | [utils_deep_merge_yaml.values](https://registry.terraform.io/providers/cloudposse/utils/latest/docs/data-sources/deep_merge_yaml) | data source |
@@ -92,14 +94,19 @@ No modules.
 | <a name="input_cloudwatch_group_nodes_kms_key_id"></a> [cloudwatch\_group\_nodes\_kms\_key\_id](#input\_cloudwatch\_group\_nodes\_kms\_key\_id) | The ARN of the KMS Key to use when encrypting log data. Please note, after the AWS KMS CMK is disassociated from the log group, AWS CloudWatch Logs stops encrypting newly ingested data for the log group. All previously ingested data remains encrypted, and AWS CloudWatch Logs requires permissions for the CMK whenever the encrypted data is requested. | `string` | `""` | no |
 | <a name="input_cloudwatch_group_nodes_retention"></a> [cloudwatch\_group\_nodes\_retention](#input\_cloudwatch\_group\_nodes\_retention) | Specifies the number of days you want to retain log events in the specified log group. Possible values are: 1, 3, 5, 7, 14, 30, 60, 90, 120, 150, 180, 365, 400, 545, 731, 1827, 3653, and 0. If you select 0, the events in the log group are always retained and never expire. | `number` | `14` | no |
 | <a name="input_cloudwatch_nodes_tags"></a> [cloudwatch\_nodes\_tags](#input\_cloudwatch\_nodes\_tags) | A map of tags to assign to the resource. | `map(any)` | `{}` | no |
-| <a name="input_cloudwatch_role_name_prefix"></a> [cloudwatch\_role\_name\_prefix](#input\_cloudwatch\_role\_name\_prefix) | The role name prefix for vector cloudwatch ingest | `string` | `"eks-irsa"` | no |
 | <a name="input_enabled"></a> [enabled](#input\_enabled) | Variable indicating whether deployment is enabled | `bool` | `true` | no |
 | <a name="input_helm_chart_name"></a> [helm\_chart\_name](#input\_helm\_chart\_name) | Helm chart name to be installed | `string` | `"vector-agent"` | no |
 | <a name="input_helm_chart_version"></a> [helm\_chart\_version](#input\_helm\_chart\_version) | Version of the Helm chart | `string` | `"0.15.1"` | no |
 | <a name="input_helm_create_namespace"></a> [helm\_create\_namespace](#input\_helm\_create\_namespace) | Whether to create k8s namespace with name defined by `k8s_namespace` | `bool` | `true` | no |
 | <a name="input_helm_release_name"></a> [helm\_release\_name](#input\_helm\_release\_name) | Helm release name | `string` | `"vector-agent"` | no |
 | <a name="input_helm_repo_url"></a> [helm\_repo\_url](#input\_helm\_repo\_url) | Helm repository | `string` | `"https://packages.timber.io/helm/latest"` | no |
+| <a name="input_k8s_assume_role_arn"></a> [k8s\_assume\_role\_arn](#input\_k8s\_assume\_role\_arn) | Whether to create and use default role or assume existing role. Useful for a variety of use cases, such as cross account access. Default (empty string) use default generted role. | `string` | `""` | no |
+| <a name="input_k8s_irsa_role_create"></a> [k8s\_irsa\_role\_create](#input\_k8s\_irsa\_role\_create) | Whether to create IRSA role and annotate service account | `bool` | `true` | no |
+| <a name="input_k8s_irsa_role_name_prefix"></a> [k8s\_irsa\_role\_name\_prefix](#input\_k8s\_irsa\_role\_name\_prefix) | The IRSA role name prefix for vector | `string` | `"eks-vector-irsa"` | no |
 | <a name="input_k8s_namespace"></a> [k8s\_namespace](#input\_k8s\_namespace) | The K8s namespace in which the vector agent will be installed | `string` | `"kube-system"` | no |
+| <a name="input_k8s_rbac_create"></a> [k8s\_rbac\_create](#input\_k8s\_rbac\_create) | Whether to create and use RBAC resources | `bool` | `true` | no |
+| <a name="input_k8s_service_account_create"></a> [k8s\_service\_account\_create](#input\_k8s\_service\_account\_create) | Whether to create Service Account | `bool` | `true` | no |
+| <a name="input_opensearch_endpoint"></a> [opensearch\_endpoint](#input\_opensearch\_endpoint) | Domain-specific endpoint used to submit index and data upload requests | `string` | `"https://opensearch.example.com"` | no |
 | <a name="input_settings"></a> [settings](#input\_settings) | Additional settings which will be passed to the Helm chart values to be merged with the values yaml, see https://artifacthub.io/packages/helm/vector/vector-agent | `map(any)` | `{}` | no |
 | <a name="input_values"></a> [values](#input\_values) | Additional values. Values will be merged, in order, as Helm does with multiple -f options | `string` | `""` | no |
 
@@ -107,7 +114,9 @@ No modules.
 
 | Name | Description |
 |------|-------------|
-| <a name="output_helm_release_attributes"></a> [helm\_release\_attributes](#output\_helm\_release\_attributes) | Helm release attributes |
+| <a name="output_helm_release_application_metadata"></a> [helm\_release\_application\_metadata](#output\_helm\_release\_application\_metadata) | Argo application helm release attributes |
+| <a name="output_helm_release_metadata"></a> [helm\_release\_metadata](#output\_helm\_release\_metadata) | Helm release attributes |
+| <a name="output_kubernetes_application_attributes"></a> [kubernetes\_application\_attributes](#output\_kubernetes\_application\_attributes) | Argo kubernetes manifest attributes |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 
 ## Contributing and reporting issues

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ To overcome this issue, the module deploys the ArgoCD application object using t
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 2.0 |
 | <a name="requirement_helm"></a> [helm](#requirement\_helm) | >= 1.0 |
-| <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | >= 2.6.0 |
+| <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | >= 2.4.0 |
 | <a name="requirement_utils"></a> [utils](#requirement\_utils) | >= 0.12.0 |
 
 ## Modules

--- a/iam.tf
+++ b/iam.tf
@@ -30,7 +30,7 @@ data "aws_iam_policy_document" "cloudwatch" {
 resource "aws_iam_policy" "cloudwatch" {
   count = local.k8s_irsa_role_create && var.cloudwatch_enabled ? 1 : 0
 
-  name        = "${var.cluster_name}-${var.helm_chart_name}-cloudwatch"
+  name        = "${var.k8s_irsa_role_name_prefix}-${var.helm_chart_name}-cloudwatch"
   path        = "/"
   description = "Policy for vector logging cloudwatch sink"
   policy      = local.k8s_assume_role ? data.aws_iam_policy_document.cloudwatch_assume[0].json : data.aws_iam_policy_document.cloudwatch[0].json
@@ -95,7 +95,7 @@ data "aws_iam_policy_document" "opensearch_assume" {
 resource "aws_iam_policy" "opensearch" {
   count = local.k8s_irsa_role_create && var.opensearch_enabled ? 1 : 0
 
-  name        = "${var.cluster_name}-${var.helm_chart_name}-opensearch"
+  name        = "${var.k8s_irsa_role_name_prefix}-${var.helm_chart_name}-opensearch"
   path        = "/"
   description = "Policy for vector logging opensearch sink"
   policy      = local.k8s_assume_role ? data.aws_iam_policy_document.opensearch_assume[0].json : data.aws_iam_policy_document.opensearch[0].json

--- a/main.tf
+++ b/main.tf
@@ -34,19 +34,10 @@ locals {
     }],
     "customConfig" : {
       "sources" : {
-        "kubelet" : {
-          "type" : "journald",
-          "include_units" : ["kubelet"]
-        },
-        "containerd" : {
-          "type" : "journald",
-          "include_units" : ["containerd"]
-        },
-        "docker" : {
-          "type" : "journald",
-          "include_units" : ["docker"]
-        },
-        "kubernetes_logs" : {
+        "journal" : {
+          "type" : "journald"
+        }
+        "kubernetes_containers" : {
           "type" : "kubernetes_logs"
         }
       }
@@ -56,9 +47,9 @@ locals {
   values_sink_cloudwatch = yamlencode({
     "customConfig" : {
       "sinks" : {
-        "cloudwatch_containers" : {
+        "cloudwatch_kubernetes_containers" : {
           "type" : "aws_cloudwatch_logs",
-          "inputs" : ["kubernetes_logs"],
+          "inputs" : ["kubernetes_containers"],
           "region" : data.aws_region.current.name,
           "group_name" : local.cloudwatch_group_name_containers,
           "stream_name" : "{{`{{ kubernetes.pod_namespace }}-{{ kubernetes.pod_name }}-{{ kubernetes.container_name }}`}}",
@@ -69,10 +60,10 @@ locals {
         },
         "cloudwatch_journal" : {
           "type" : "aws_cloudwatch_logs",
-          "inputs" : ["kubelet", "containerd", "docker"],
+          "inputs" : ["journal"],
           "region" : data.aws_region.current.name,
           "group_name" : local.cloudwatch_group_name_nodes,
-          "stream_name" : "{{`{{ host }}-{{ _SYSTEMD_UNIT }}`}}",
+          "stream_name" : "{{`{{ host }}`}}",
           "create_missing_group" : false,
           "encoding" : {
             "codec" : "json"

--- a/output.tf
+++ b/output.tf
@@ -12,3 +12,8 @@ output "kubernetes_application_attributes" {
   description = "Argo kubernetes manifest attributes"
   value       = try(kubernetes_manifest.self, {})
 }
+
+output "iam_role_attributes" {
+  description = "Vector IAM role atributes"
+  value       = try(aws_iam_role.vector[0], {})
+}

--- a/output.tf
+++ b/output.tf
@@ -1,4 +1,14 @@
-output "helm_release_attributes" {
+output "helm_release_metadata" {
   description = "Helm release attributes"
-  value       = helm_release.self
+  value       = try(helm_release.self[0].metadata, {})
+}
+
+output "helm_release_application_metadata" {
+  description = "Argo application helm release attributes"
+  value       = try(helm_release.argocd_application[0].metadata, {})
+}
+
+output "kubernetes_application_attributes" {
+  description = "Argo kubernetes manifest attributes"
+  value       = try(kubernetes_manifest.self, {})
 }

--- a/variables.tf
+++ b/variables.tf
@@ -145,6 +145,25 @@ variable "cloudwatch_nodes_tags" {
   description = "A map of tags to assign to the resource."
 }
 
+# Vector OpenSearch sink configuration
+variable "opensearch_enabled" {
+  type        = bool
+  default     = false
+  description = "Variable indicating whether default opensearch group with iam role is created and configured as vector sink"
+}
+
+variable "opensearch_domain_arn" {
+  type        = list(string)
+  default     = ["*"]
+  description = "List of OpenSearch arns to allow for the vector role. Default all OpenSearch domains."
+}
+
+variable "opensearch_domain_action" {
+  type        = list(string)
+  default     = ["es:ESHttpGet", "es:ESHttpPut", "es:ESHttpPost"]
+  description = "List of actions to allow for the vector role, _e.g._ `es:ESHttpGet`, `es:ESHttpPut`, `es:ESHttpPost`"
+}
+
 variable "opensearch_endpoint" {
   type        = string
   default     = "https://opensearch.example.com"

--- a/variables.tf
+++ b/variables.tf
@@ -55,6 +55,35 @@ variable "k8s_namespace" {
   description = "The K8s namespace in which the vector agent will be installed"
 }
 
+variable "k8s_rbac_create" {
+  type        = bool
+  default     = true
+  description = "Whether to create and use RBAC resources"
+}
+
+variable "k8s_service_account_create" {
+  type        = bool
+  default     = true
+  description = "Whether to create Service Account"
+}
+
+variable "k8s_irsa_role_create" {
+  type        = bool
+  default     = true
+  description = "Whether to create IRSA role and annotate service account"
+}
+
+variable "k8s_irsa_role_name_prefix" {
+  type        = string
+  default     = "eks-vector-irsa"
+  description = "The IRSA role name prefix for vector"
+}
+
+variable "k8s_assume_role_arn" {
+  default     = ""
+  description = "Whether to create and use default role or assume existing role. Useful for a variety of use cases, such as cross account access. Default (empty string) use default generted role."
+}
+
 variable "settings" {
   type        = map(any)
   default     = {}
@@ -116,12 +145,13 @@ variable "cloudwatch_nodes_tags" {
   description = "A map of tags to assign to the resource."
 }
 
-variable "cloudwatch_role_name_prefix" {
+variable "opensearch_endpoint" {
   type        = string
-  default     = "eks-irsa"
-  description = "The role name prefix for vector cloudwatch ingest"
+  default     = "https://opensearch.example.com"
+  description = "Domain-specific endpoint used to submit index and data upload requests"
 }
 
+# Argo settings
 variable "argo_namespace" {
   type        = string
   default     = "argo"

--- a/versions.tf
+++ b/versions.tf
@@ -12,7 +12,7 @@ terraform {
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"
-      version = ">= 2.6.0"
+      version = ">= 2.4.0"
     }
     utils = {
       source  = "cloudposse/utils"

--- a/versions.tf
+++ b/versions.tf
@@ -10,6 +10,10 @@ terraform {
       source  = "hashicorp/helm"
       version = ">= 1.0"
     }
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = ">= 2.6.0"
+    }
     utils = {
       source  = "cloudposse/utils"
       version = ">= 0.12.0"


### PR DESCRIPTION
* Align inputs with other eks terraform modules
* Add opensearch / elasticsearch support
* Add more outputs
* Add kubernetes provider with minimal supported version for GA manifests
* Add ability to assume defined roles instead of predefined
* Change vector source config to journal and containers logs
* Change cloudwatch journal stream name
* Cloudwatch policy has been renamed to match predixed role name

Breaking changes:
* IRSA has been renamed to be more generic (terraform resource and role name)
* cloudwatch_role_name_prefix is now deprecated and replaced with k8s_irsa_role_name_prefix
* replaced helm_release_attributes with helm_release_metadata (fix sensitive terraform field matching)