### PR TITLE
Add auth strategy aws to sink configuration only if irsa_role_create …

### DIFF
--- a/values.tf
+++ b/values.tf
@@ -117,9 +117,6 @@ locals {
             "namespace" : "pods"
           },
           "compression" : "gzip",
-          "auth" : {
-            "strategy" : "aws",
-          },
           "aws" : {
             "region" : data.aws_region.current.name
           }
@@ -138,9 +135,6 @@ locals {
             "namespace" : "hosts"
           },
           "compression" : "gzip",
-          "auth" : {
-            "strategy" : "aws",
-          },
           "aws" : {
             "region" : data.aws_region.current.name
           }
@@ -160,6 +154,23 @@ locals {
         "elasticsearch_journal" : {
           "auth" : {
             "assume_role" : var.irsa_assume_role_arn
+          }
+        }
+      }
+    }
+  })
+
+  helm_values_sink_opensearch_auth_strategy = yamlencode({
+    "customConfig" : {
+      "sinks" : {
+        "elasticsearch_kubernetes_containers" : {
+          "auth" : {
+            "strategy" : "aws",
+          }
+        },
+        "elasticsearch_journal" : {
+          "auth" : {
+            "strategy" : "aws",
           }
         }
       }
@@ -207,6 +218,7 @@ data "utils_deep_merge_yaml" "values" {
     var.cloudwatch_enabled ? local.helm_values_sink_cloudwatch : "",
     var.cloudwatch_enabled && var.irsa_assume_role_enabled ? local.helm_values_sink_cloudwatch_assume_role : "",
     var.opensearch_enabled ? local.helm_values_sink_opensearch : "",
+    var.opensearch_enabled && var.irsa_role_create ? local.helm_values_sink_opensearch_auth_strategy : "",
     var.opensearch_enabled && var.irsa_assume_role_enabled ? local.helm_values_sink_opensearch_assume_role : "",
     var.loki_enabled ? local.helm_values_sink_loki : "",
     var.values


### PR DESCRIPTION
# Description

On opensearch clusters without AWS or basic authentication we need to omit related vector configuration otherwise vector isn't able to ship logs to opensearch sink.

## Type of change

- [x] A bug fix (PR prefix `fix`)
- [ ] A new feature (PR prefix `feat`)
- [ ] A code change that neither fixes a bug nor adds a feature (PR prefix `refactor`)
- [ ] Adding missing tests or correcting existing tests (PR prefix `test`)
- [ ] Changes that do not affect the meaning of the code like white-spaces, formatting, missing semi-colons, etc. (PR prefix `style`)
- [ ] Changes to our CI configuration files and scripts (PR prefix `ci`)
- [ ] Documentation only changes (PR prefix `docs`)

## How Has This Been Tested?
With `irsa_role_create      = true`  "auth" : { "strategy" : "aws"} was correctly merged into custom config of both sinks.
With `irsa_role_create      = false`  auth strategy isn't present in merged configuration of vector. 
Both changes were verified in running pod after fresh redeploy.

