### PR TITLE
fix(values): changing kubernetes_cluster label to cluster

### DIFF
--- a/values.tf
+++ b/values.tf
@@ -189,7 +189,7 @@ locals {
             "container" : "{{`{{ kubernetes.container_name }}`}}"
             "filename" : "{{`{{ file }}`}}"
             "forwarder" : "vector"
-            "kubernetes_cluster" : var.loki_label_cluster
+            "cluster" : var.loki_label_cluster
             "log_source" : "containers"
             "namespace" : "{{`{{ kubernetes.pod_namespace }}`}}"
             "node_name" : "{{`{{ kubernetes.pod_node_name }}`}}"


### PR DESCRIPTION
# Description

label `cluster` is used in community, hence we want to implement same pattern 

## Type of change

- [x] A bug fix (PR prefix `fix`)
- [ ] A new feature (PR prefix `feat`)
- [ ] A code change that neither fixes a bug nor adds a feature (PR prefix `refactor`)
- [ ] Adding missing tests or correcting existing tests (PR prefix `test`)
- [ ] Changes that do not affect the meaning of the code like white-spaces, formatting, missing semi-colons, etc. (PR prefix `style`)
- [ ] Changes to our CI configuration files and scripts (PR prefix `ci`)
- [ ] Documentation only changes (PR prefix `docs`)

