### PR TITLE
feat(loki): rename node_name label

### DIFF
--- a/values.tf
+++ b/values.tf
@@ -193,7 +193,7 @@ locals {
             "cluster" : var.loki_label_cluster
             "log_source" : "containers"
             "namespace" : "{{`{{ kubernetes.pod_namespace }}`}}"
-            "node_name" : "{{`{{ kubernetes.pod_node_name }}`}}"
+            "node" : "{{`{{ kubernetes.pod_node_name }}`}}"
             "pod" : "{{`{{ kubernetes.pod_name }}`}}"
             "stream" : "{{`{{ .stream }}`}}"
           }


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change, provide a justification and which issue is fixed.
-->
- Rename label `node_name` to `node` for Loki container sink (alignment with Prometheus metric label for node)
- Enable `out_of_order_action` on `nodes` Loki sink

## Type of change

- [x] A bug fix (PR prefix `fix`)
- [x] A new feature (PR prefix `feat`)
- [ ] A code change that neither fixes a bug nor adds a feature (PR prefix `refactor`)
- [ ] Adding missing tests or correcting existing tests (PR prefix `test`)
- [ ] Changes that do not affect the meaning of the code like white-spaces, formatting, missing semi-colons, etc. (PR prefix `style`)
- [ ] Changes to our CI configuration files and scripts (PR prefix `ci`)
- [ ] Documentation only changes (PR prefix `docs`)

## How Has This Been Tested?

<!--
Please describe the tests that you ran to verify your changes.
-->

- QLA
