### PR TITLE
feat(loki): remove filename label

### DIFF
--- a/values.tf
+++ b/values.tf
@@ -185,10 +185,11 @@ locals {
           "inputs" : ["kubernetes_containers"]
           "endpoint" : var.loki_endpoint
           "out_of_order_action" : "accept"
+          "remove_label_fields" : true
           "labels" : {
             "app" : "{{`{{ kubernetes.pod_labels.\"app.kubernetes.io/name\" }}`}}"
             "container" : "{{`{{ kubernetes.container_name }}`}}"
-            "filename" : "{{`{{ file }}`}}"
+            "file" : "{{`{{ file }}`}}"
             "forwarder" : "vector"
             "cluster" : var.loki_label_cluster
             "log_source" : "containers"
@@ -205,6 +206,8 @@ locals {
           "type" : "loki"
           "inputs" : ["journal"]
           "endpoint" : var.loki_endpoint
+          "out_of_order_action" : "accept"
+          "remove_label_fields" : true
           "labels" : {
             "forwarder" : "vector"
             "cluster" : var.loki_label_cluster

--- a/values.tf
+++ b/values.tf
@@ -189,7 +189,6 @@ locals {
           "labels" : {
             "app" : "{{`{{ kubernetes.pod_labels.\"app.kubernetes.io/name\" }}`}}"
             "container" : "{{`{{ kubernetes.container_name }}`}}"
-            "file" : "{{`{{ file }}`}}"
             "forwarder" : "vector"
             "cluster" : var.loki_label_cluster
             "log_source" : "containers"


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change, provide a justification and which issue is fixed.
-->

I noticed that we are setting a `filename` label and a `file` field inside the log entry both giving the same value. We can remove the `filename` label in favor of the `file` field to avoid high cardinality.

Also, setting `remove_label_fields` will remove any field from the log entry when it was already sent as a label.

## Type of change

- [ ] A bug fix (PR prefix `fix`)
- [x] A new feature (PR prefix `feat`)
- [ ] A code change that neither fixes a bug nor adds a feature (PR prefix `refactor`)
- [ ] Adding missing tests or correcting existing tests (PR prefix `test`)
- [ ] Changes that do not affect the meaning of the code like white-spaces, formatting, missing semi-colons, etc. (PR prefix `style`)
- [ ] Changes to our CI configuration files and scripts (PR prefix `ci`)
- [ ] Documentation only changes (PR prefix `docs`)

## How Has This Been Tested?

<!--
Please describe the tests that you ran to verify your changes.
-->
