### PR TITLE
feat(loki): add internal_logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ No modules.
 | <a name="input_loki_enabled"></a> [loki\_enabled](#input\_loki\_enabled) | Variable indicating whether Loki is configured as Vector sink | `bool` | `false` | no |
 | <a name="input_loki_endpoint"></a> [loki\_endpoint](#input\_loki\_endpoint) | Domain-specific endpoint used to submit index and data upload requests | `string` | `"https://loki.example.com"` | no |
 | <a name="input_loki_internal_logs_enabled"></a> [loki\_internal\_logs\_enabled](#input\_loki\_internal\_logs\_enabled) | Whether Vector internal logs should be sent to Loki | `bool` | `false` | no |
-| <a name="input_loki_internal_logs_severity"></a> [loki\_internal\_logs\_severity](#input\_loki\_internal\_logs\_severity) | Internal log severity to be sent to Loki | `string` | `"warn"` | no |
+| <a name="input_loki_internal_logs_severity"></a> [loki\_internal\_logs\_severity](#input\_loki\_internal\_logs\_severity) | The severity of internal logs to be sent to Loki | `string` | `"warn"` | no |
 | <a name="input_loki_label_cluster"></a> [loki\_label\_cluster](#input\_loki\_label\_cluster) | Cluster label with kubernetes cluster name as a value. Labels are attached to each batch of events | `string` | `"example-cluster"` | no |
 | <a name="input_namespace"></a> [namespace](#input\_namespace) | The K8s namespace in which the vector agent will be installed | `string` | `"kube-system"` | no |
 | <a name="input_opensearch_domain_arn"></a> [opensearch\_domain\_arn](#input\_opensearch\_domain\_arn) | List of OpenSearch arns to allow for the vector role. Default all OpenSearch domains. | `list(string)` | <pre>[<br>  "*"<br>]</pre> | no |

--- a/README.md
+++ b/README.md
@@ -163,6 +163,7 @@ No modules.
 | <a name="input_irsa_tags"></a> [irsa\_tags](#input\_irsa\_tags) | IRSA resources tags | `map(string)` | `{}` | no |
 | <a name="input_loki_enabled"></a> [loki\_enabled](#input\_loki\_enabled) | Variable indicating whether Loki is configured as Vector sink | `bool` | `false` | no |
 | <a name="input_loki_endpoint"></a> [loki\_endpoint](#input\_loki\_endpoint) | Domain-specific endpoint used to submit index and data upload requests | `string` | `"https://loki.example.com"` | no |
+| <a name="input_loki_internal_logs_enabled"></a> [loki\_internal\_logs\_enabled](#input\_loki\_internal\_logs\_enabled) | Variable indicating whether Vector is scraping internal\_logs | `bool` | `false` | no |
 | <a name="input_loki_label_cluster"></a> [loki\_label\_cluster](#input\_loki\_label\_cluster) | Cluster label with kubernetes cluster name as a value. Labels are attached to each batch of events | `string` | `"example-cluster"` | no |
 | <a name="input_namespace"></a> [namespace](#input\_namespace) | The K8s namespace in which the vector agent will be installed | `string` | `"kube-system"` | no |
 | <a name="input_opensearch_domain_arn"></a> [opensearch\_domain\_arn](#input\_opensearch\_domain\_arn) | List of OpenSearch arns to allow for the vector role. Default all OpenSearch domains. | `list(string)` | <pre>[<br>  "*"<br>]</pre> | no |

--- a/README.md
+++ b/README.md
@@ -164,6 +164,7 @@ No modules.
 | <a name="input_loki_enabled"></a> [loki\_enabled](#input\_loki\_enabled) | Variable indicating whether Loki is configured as Vector sink | `bool` | `false` | no |
 | <a name="input_loki_endpoint"></a> [loki\_endpoint](#input\_loki\_endpoint) | Domain-specific endpoint used to submit index and data upload requests | `string` | `"https://loki.example.com"` | no |
 | <a name="input_loki_internal_logs_enabled"></a> [loki\_internal\_logs\_enabled](#input\_loki\_internal\_logs\_enabled) | Variable indicating whether Vector is scraping internal\_logs | `bool` | `false` | no |
+| <a name="input_loki_internal_logs_filter_log_level"></a> [loki\_internal\_logs\_filter\_log\_level](#input\_loki\_internal\_logs\_filter\_log\_level) | Variable defining log level to be filtered before logs are send to Loki endpoint | `string` | `"warn"` | no |
 | <a name="input_loki_label_cluster"></a> [loki\_label\_cluster](#input\_loki\_label\_cluster) | Cluster label with kubernetes cluster name as a value. Labels are attached to each batch of events | `string` | `"example-cluster"` | no |
 | <a name="input_namespace"></a> [namespace](#input\_namespace) | The K8s namespace in which the vector agent will be installed | `string` | `"kube-system"` | no |
 | <a name="input_opensearch_domain_arn"></a> [opensearch\_domain\_arn](#input\_opensearch\_domain\_arn) | List of OpenSearch arns to allow for the vector role. Default all OpenSearch domains. | `list(string)` | <pre>[<br>  "*"<br>]</pre> | no |

--- a/README.md
+++ b/README.md
@@ -163,8 +163,8 @@ No modules.
 | <a name="input_irsa_tags"></a> [irsa\_tags](#input\_irsa\_tags) | IRSA resources tags | `map(string)` | `{}` | no |
 | <a name="input_loki_enabled"></a> [loki\_enabled](#input\_loki\_enabled) | Variable indicating whether Loki is configured as Vector sink | `bool` | `false` | no |
 | <a name="input_loki_endpoint"></a> [loki\_endpoint](#input\_loki\_endpoint) | Domain-specific endpoint used to submit index and data upload requests | `string` | `"https://loki.example.com"` | no |
-| <a name="input_loki_internal_logs_enabled"></a> [loki\_internal\_logs\_enabled](#input\_loki\_internal\_logs\_enabled) | Variable indicating whether Vector is scraping internal\_logs | `bool` | `false` | no |
-| <a name="input_loki_internal_logs_filter_log_level"></a> [loki\_internal\_logs\_filter\_log\_level](#input\_loki\_internal\_logs\_filter\_log\_level) | Variable defining log level to be filtered before logs are send to Loki endpoint | `string` | `"warn"` | no |
+| <a name="input_loki_internal_logs_enabled"></a> [loki\_internal\_logs\_enabled](#input\_loki\_internal\_logs\_enabled) | Whether Vector internal logs should be sent to Loki | `bool` | `false` | no |
+| <a name="input_loki_internal_logs_severity"></a> [loki\_internal\_logs\_severity](#input\_loki\_internal\_logs\_severity) | Internal log severity to be sent to Loki | `string` | `"warn"` | no |
 | <a name="input_loki_label_cluster"></a> [loki\_label\_cluster](#input\_loki\_label\_cluster) | Cluster label with kubernetes cluster name as a value. Labels are attached to each batch of events | `string` | `"example-cluster"` | no |
 | <a name="input_namespace"></a> [namespace](#input\_namespace) | The K8s namespace in which the vector agent will be installed | `string` | `"kube-system"` | no |
 | <a name="input_opensearch_domain_arn"></a> [opensearch\_domain\_arn](#input\_opensearch\_domain\_arn) | List of OpenSearch arns to allow for the vector role. Default all OpenSearch domains. | `list(string)` | <pre>[<br>  "*"<br>]</pre> | no |

--- a/values.tf
+++ b/values.tf
@@ -163,12 +163,12 @@ locals {
   helm_values_sink_loki_internal_logs = yamlencode({
     "customConfig" : {
       "transforms" : {
-        "filter_logs" : {
+        "loki_internal_logs_severity_filter" : {
           "type" : "filter",
-          "inputs" : ["internal_logs_severity_map"],
-          "condition" = "includes(array(.log_levels.${upper(var.loki_internal_logs_filter_log_level)}) ?? [], .metadata.level)"
+          "inputs" : ["loki_internal_logs_severity_map"],
+          "condition" = "includes(array(.log_levels.${upper(var.loki_internal_logs_severity)}) ?? [], .metadata.level)"
         },
-        "internal_logs_severity_map" = {
+        "loki_internal_logs_severity_map" = {
           "type" = "remap"
           "inputs" = [
             "internal_logs"
@@ -182,10 +182,10 @@ locals {
             .log_levels.FATAL  = ["FATAL"]
           EOT
         }
-        "enrich_internal_logs" = {
+        "loki_internal_logs_enrichment" = {
           "type" = "remap"
           "inputs" = [
-            "filter_logs"
+            "loki_internal_logs_severity_filter"
           ]
           "source" = <<-EOT
             .kubernetes.pod_namespace = "$${VECTOR_SELF_POD_NAMESPACE:-null}"
@@ -198,7 +198,7 @@ locals {
       "sinks" : {
         "loki_internal_logs" : {
           "type" : "loki"
-          "inputs" : ["enrich_internal_logs"]
+          "inputs" : ["loki_internal_logs_enrichment"]
           "endpoint" : var.loki_endpoint
           "out_of_order_action" : "accept"
           "remove_label_fields" : true

--- a/values.tf
+++ b/values.tf
@@ -194,7 +194,7 @@ locals {
             "namespace" : "{{`{{ kubernetes.pod_namespace }}`}}"
             "node" : "{{`{{ kubernetes.pod_node_name }}`}}"
             "pod" : "{{`{{ kubernetes.pod_name }}`}}"
-            "severity"  : "{{`{{ .metadata.level }}`}}"
+            "severity" : "{{`{{ .metadata.level }}`}}"
           }
           "encoding" : {
             "codec" : "json"
@@ -203,7 +203,7 @@ locals {
       }
       "sources" : {
         "internal_logs" : {
-          "type": "internal_logs"
+          "type" : "internal_logs"
         }
       }
     }

--- a/values.tf
+++ b/values.tf
@@ -194,6 +194,7 @@ locals {
             "namespace" : "{{`{{ kubernetes.pod_namespace }}`}}"
             "node" : "{{`{{ kubernetes.pod_node_name }}`}}"
             "pod" : "{{`{{ kubernetes.pod_name }}`}}"
+            "severity"  = "{{`{{ .metadata.level }}`}}"
           }
           "encoding" : {
             "codec" : "json"

--- a/values.tf
+++ b/values.tf
@@ -194,7 +194,7 @@ locals {
             "namespace" : "{{`{{ kubernetes.pod_namespace }}`}}"
             "node" : "{{`{{ kubernetes.pod_node_name }}`}}"
             "pod" : "{{`{{ kubernetes.pod_name }}`}}"
-            "severity"  = "{{`{{ .metadata.level }}`}}"
+            "severity"  : "{{`{{ .metadata.level }}`}}"
           }
           "encoding" : {
             "codec" : "json"

--- a/variables.tf
+++ b/variables.tf
@@ -208,6 +208,12 @@ variable "loki_label_cluster" {
   description = "Cluster label with kubernetes cluster name as a value. Labels are attached to each batch of events"
 }
 
+variable "loki_internal_logs_enabled" {
+  type        = bool
+  default     = false
+  description = "Variable indicating whether Vector is scraping internal_logs"
+}
+
 # ================ argo variables ================
 
 variable "argo_namespace" {

--- a/variables.tf
+++ b/variables.tf
@@ -211,13 +211,13 @@ variable "loki_label_cluster" {
 variable "loki_internal_logs_enabled" {
   type        = bool
   default     = false
-  description = "Variable indicating whether Vector is scraping internal_logs"
+  description = "Whether Vector internal logs should be sent to Loki"
 }
 
-variable "loki_internal_logs_filter_log_level" {
+variable "loki_internal_logs_severity" {
   type        = string
   default     = "warn"
-  description = "Variable defining log level to be filtered before logs are send to Loki endpoint"
+  description = "Internal log severity to be sent to Loki"
 }
 
 # ================ argo variables ================

--- a/variables.tf
+++ b/variables.tf
@@ -217,7 +217,7 @@ variable "loki_internal_logs_enabled" {
 variable "loki_internal_logs_severity" {
   type        = string
   default     = "warn"
-  description = "Internal log severity to be sent to Loki"
+  description = "The severity of internal logs to be sent to Loki"
 }
 
 # ================ argo variables ================

--- a/variables.tf
+++ b/variables.tf
@@ -214,6 +214,12 @@ variable "loki_internal_logs_enabled" {
   description = "Variable indicating whether Vector is scraping internal_logs"
 }
 
+variable "loki_internal_logs_filter_log_level" {
+  type        = string
+  default     = "warn"
+  description = "Variable defining log level to be filtered before logs are send to Loki endpoint"
+}
+
 # ================ argo variables ================
 
 variable "argo_namespace" {


### PR DESCRIPTION
# Description

Vector is not collecting internal_logs and sending those logs to LOKI endpoint. Therefore we want ability to instrument Vector to scrape internal_logs as well. Internal_logs are not exposing labels about pod/node/etc therefore it needs to be enriched using vector transform operation.

## Type of change

- [ ] A bug fix (PR prefix `fix`)
- [x] A new feature (PR prefix `feat`)
- [ ] A code change that neither fixes a bug nor adds a feature (PR prefix `refactor`)
- [ ] Adding missing tests or correcting existing tests (PR prefix `test`)
- [ ] Changes that do not affect the meaning of the code like white-spaces, formatting, missing semi-colons, etc. (PR prefix `style`)
- [ ] Changes to our CI configuration files and scripts (PR prefix `ci`)
- [ ] Documentation only changes (PR prefix `docs`)

## How Has This Been Tested?
Change was tested in LARA, by setting loki_internal_logs_enabled = false/true. Checked in grafana if logs are delivered to loki with correct labels. Checked if custom configs are not overwritten. 
